### PR TITLE
Drop support for old Puppet versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Tested with Travis CI
 This module manages Postfix.
 
 CentOS, RHEL, Scientific and Oracle Enterprise Linux is supported using Puppet
-4.6.0 or later.
+5 or later.
 
 ## Setup
 
@@ -173,7 +173,7 @@ boolean values. Any multi-valued setting accepts an array of values.
 For referring to other settings, ensure that the `$` is escaped appropriately
 using either `\` or `''` to prevent Puppet expanding the variable itself.
 
-This module has been built on and tested against Puppet 4.6.0 and higher.
+This module has been built on and tested against Puppet 5 and higher.
 
 The module has been tested on:
 

--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.6.0 <6.0.0"
+      "version_requirement": ">=5.5.10 <7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Add support for 6.x versions too.