### PR TITLE
Add support for EL8

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,9 @@ fixtures:
   symlinks:
     postfix: "#{source_dir}"
   forge_modules:
+    augeas:
+      repo: "camptocamp/augeas"
+      ref: "1.9.0"
     augeasproviders_core:
       repo: "herculesteam/augeasproviders_core"
       ref: "2.6.0"

--- a/files/postfix_master.aug
+++ b/files/postfix_master.aug
@@ -1,0 +1,58 @@
+(* Postfix_Master module for Augeas
+ Author: Free Ekanayaka <free@64studio.com>
+
+ Reference:
+
+*)
+
+module Postfix_Master =
+
+   autoload xfm
+
+(************************************************************************
+ *                           USEFUL PRIMITIVES
+ *************************************************************************)
+
+let eol        = Util.eol
+let ws         = del /[ \t\n]+/ " "
+let comment    = Util.comment
+let empty      = Util.empty
+
+let word       = /[A-Za-z0-9_.:-]+/
+let words      =
+     let char_start = /[A-Za-z0-9$!(){}=_.,:@-]/
+  in let char_end = char_start | /[]["\/]/
+  in let char_middle = char_end | " "
+  in char_start . char_middle* . char_end
+
+let bool       = /y|n|-/
+let integer    = /([0-9]+|-)\??/
+let command   = words . (/[ \t]*\n[ \t]+/ . words)*
+
+let field (l:string) (r:regexp)
+               = [ label l . store r ]
+
+(************************************************************************
+ *                               ENTRIES
+ *************************************************************************)
+
+let entry     = [ key word . ws
+                . field "type"         /inet|unix(-dgram)?|fifo|pass/  . ws
+                . field "private"      bool                   . ws
+                . field "unprivileged" bool                   . ws
+                . field "chroot"       bool                   . ws
+                . field "wakeup"       integer                . ws
+                . field "limit"        integer                . ws
+                . field "command"      command
+                . eol ]
+
+(************************************************************************
+ *                                LENS
+ *************************************************************************)
+
+let lns        = (comment|empty|entry) *
+
+let filter     = incl "/etc/postfix/master.cf"
+               . incl "/usr/local/etc/postfix/master.cf"
+
+let xfm        = transform lns filter

--- a/lib/puppet/type/postfix_master.rb
+++ b/lib/puppet/type/postfix_master.rb
@@ -34,7 +34,7 @@ string.'
   newparam(:type) do
     desc 'The service type.'
     isnamevar
-    newvalues('inet', 'unix', 'fifo', 'pass')
+    newvalues('inet', 'unix', 'unix-dgram', 'fifo', 'pass')
     munge do |value|
       value.to_s
     end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,12 +20,19 @@ class postfix::config {
     mode   => '0644',
   }
 
+  # Augeas 1.12.0 has a lens that doesn't recognise unix-dgram in master.cf
+  augeas::lens { 'postfix_master':
+    lens_content => file("${module_name}/postfix_master.aug"),
+    stock_since  => '1.12.1',
+  }
+
   Postfix_main {
     target => $main_cf,
   }
 
   Postfix_master {
-    target => $master_cf,
+    target  => $master_cf,
+    require => Augeas::Lens['postfix_master'],
   }
 
   resources { 'postfix_main':
@@ -33,7 +40,8 @@ class postfix::config {
   }
 
   resources { 'postfix_master':
-    purge => true,
+    purge   => true,
+    require => Augeas::Lens['postfix_master'],
   }
 
   $config = delete_undef_values({
@@ -190,6 +198,7 @@ class postfix::config {
     'command_execution_directory'                            => $postfix::command_execution_directory,
     'command_expansion_filter'                               => $postfix::command_expansion_filter,
     'command_time_limit'                                     => $postfix::command_time_limit,
+    'compatibility_level'                                    => $postfix::compatibility_level,
     'config_directory'                                       => $postfix::config_directory,
     'connection_cache_protocol_timeout'                      => $postfix::connection_cache_protocol_timeout,
     'connection_cache_service_name'                          => $postfix::connection_cache_service_name,
@@ -722,6 +731,7 @@ class postfix::config {
     'message_reject_characters'                              => $postfix::message_reject_characters,
     'message_size_limit'                                     => $postfix::message_size_limit,
     'message_strip_characters'                               => $postfix::message_strip_characters,
+    'meta_directory'                                         => $postfix::meta_directory,
     'milter_command_timeout'                                 => $postfix::milter_command_timeout,
     'milter_connect_macros'                                  => $postfix::milter_connect_macros,
     'milter_connect_timeout'                                 => $postfix::milter_connect_timeout,
@@ -1070,6 +1080,12 @@ class postfix::config {
     'sendmail_path'                                          => $postfix::sendmail_path,
     'service_throttle_time'                                  => $postfix::service_throttle_time,
     'setgid_group'                                           => $postfix::setgid_group,
+    'shlib_directory'                                        => $postfix::shlib_directory ? {
+      undef   => undef,
+      false   => 'no',
+      true    => 'yes',
+      default => $postfix::shlib_directory,
+    },
     'show_user_unknown_table_name'                           => $postfix::show_user_unknown_table_name ? {
       undef   => undef,
       false   => 'no',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,7 @@
 # @param command_execution_directory
 # @param command_expansion_filter
 # @param command_time_limit
+# @param compatibility_level
 # @param config_directory
 # @param connection_cache_protocol_timeout
 # @param connection_cache_service_name
@@ -332,6 +333,7 @@
 # @param message_reject_characters
 # @param message_size_limit
 # @param message_strip_characters
+# @param meta_directory
 # @param milter_command_timeout
 # @param milter_connect_macros
 # @param milter_connect_timeout
@@ -478,6 +480,7 @@
 # @param sendmail_path
 # @param service_throttle_time
 # @param setgid_group
+# @param shlib_directory
 # @param show_user_unknown_table_name
 # @param showq_service_name
 # @param smtp_address_preference
@@ -840,6 +843,7 @@ class postfix (
   Optional[String]                    $command_execution_directory                            = undef,
   Optional[String]                    $command_expansion_filter                               = undef,
   Optional[String]                    $command_time_limit                                     = undef,
+  Optional[String]                    $compatibility_level                                    = $postfix::params::compatibility_level,
   Optional[String]                    $config_directory                                       = undef,
   Optional[String]                    $connection_cache_protocol_timeout                      = undef,
   Optional[String]                    $connection_cache_service_name                          = undef,
@@ -1058,6 +1062,7 @@ class postfix (
   Optional[String]                    $message_reject_characters                              = undef,
   Optional[String]                    $message_size_limit                                     = undef,
   Optional[String]                    $message_strip_characters                               = undef,
+  Optional[String]                    $meta_directory                                         = $postfix::params::meta_directory,
   Optional[String]                    $milter_command_timeout                                 = undef,
   Optional[String]                    $milter_connect_macros                                  = undef,
   Optional[String]                    $milter_connect_timeout                                 = undef,
@@ -1204,6 +1209,7 @@ class postfix (
   Optional[String]                    $sendmail_path                                          = $postfix::params::sendmail_path,
   Optional[String]                    $service_throttle_time                                  = undef,
   Optional[String]                    $setgid_group                                           = $postfix::params::setgid_group,
+  Optional[Variant[Boolean, String]]  $shlib_directory                                        = $postfix::params::shlib_directory,
   Optional[Variant[Boolean, String]]  $show_user_unknown_table_name                           = undef,
   Optional[String]                    $showq_service_name                                     = undef,
   Optional[String]                    $smtp_address_preference                                = undef,
@@ -1266,8 +1272,8 @@ class postfix (
   Optional[Variant[Boolean, String]]  $smtp_skip_5xx_greeting                                 = undef,
   Optional[Variant[Boolean, String]]  $smtp_skip_quit_response                                = undef,
   Optional[String]                    $smtp_starttls_timeout                                  = undef,
-  Optional[String]                    $smtp_tls_cafile                                        = undef,
-  Optional[String]                    $smtp_tls_capath                                        = undef,
+  Optional[String]                    $smtp_tls_cafile                                        = $postfix::params::smtp_tls_cafile,
+  Optional[String]                    $smtp_tls_capath                                        = $postfix::params::smtp_tls_capath,
   Optional[Variant[Boolean, String]]  $smtp_tls_block_early_mail_reply                        = undef,
   Optional[String]                    $smtp_tls_cert_file                                     = undef,
   Optional[String]                    $smtp_tls_ciphers                                       = undef,
@@ -1290,7 +1296,7 @@ class postfix (
   Optional[Array[String, 1]]          $smtp_tls_protocols                                     = undef,
   Optional[String]                    $smtp_tls_scert_verifydepth                             = undef,
   Optional[Array[String, 1]]          $smtp_tls_secure_cert_match                             = undef,
-  Optional[String]                    $smtp_tls_security_level                                = undef,
+  Optional[String]                    $smtp_tls_security_level                                = $postfix::params::smtp_tls_security_level,
   Optional[String]                    $smtp_tls_session_cache_database                        = undef,
   Optional[String]                    $smtp_tls_session_cache_timeout                         = undef,
   Optional[Array[String, 1]]          $smtp_tls_verify_cert_match                             = undef,
@@ -1366,7 +1372,7 @@ class postfix (
   Optional[Variant[Boolean, String]]  $smtpd_tls_ask_ccert                                    = undef,
   Optional[Variant[Boolean, String]]  $smtpd_tls_auth_only                                    = undef,
   Optional[String]                    $smtpd_tls_ccert_verifydepth                            = undef,
-  Optional[String]                    $smtpd_tls_cert_file                                    = undef,
+  Optional[String]                    $smtpd_tls_cert_file                                    = $postfix::params::smtpd_tls_cert_file,
   Optional[String]                    $smtpd_tls_ciphers                                      = undef,
   Optional[String]                    $smtpd_tls_dcert_file                                   = undef,
   Optional[String]                    $smtpd_tls_dh1024_param_file                            = undef,
@@ -1377,7 +1383,7 @@ class postfix (
   Optional[String]                    $smtpd_tls_eecdh_grade                                  = undef,
   Optional[Array[String, 1]]          $smtpd_tls_exclude_ciphers                              = undef,
   Optional[String]                    $smtpd_tls_fingerprint_digest                           = undef,
-  Optional[String]                    $smtpd_tls_key_file                                     = undef,
+  Optional[String]                    $smtpd_tls_key_file                                     = $postfix::params::smtpd_tls_key_file,
   Optional[String]                    $smtpd_tls_loglevel                                     = undef,
   Optional[String]                    $smtpd_tls_mandatory_ciphers                            = undef,
   Optional[Array[String, 1]]          $smtpd_tls_mandatory_exclude_ciphers                    = undef,
@@ -1385,7 +1391,7 @@ class postfix (
   Optional[Array[String, 1]]          $smtpd_tls_protocols                                    = undef,
   Optional[Variant[Boolean, String]]  $smtpd_tls_received_header                              = undef,
   Optional[Variant[Boolean, String]]  $smtpd_tls_req_ccert                                    = undef,
-  Optional[String]                    $smtpd_tls_security_level                               = undef,
+  Optional[String]                    $smtpd_tls_security_level                               = $postfix::params::smtpd_tls_security_level,
   Optional[String]                    $smtpd_tls_session_cache_database                       = undef,
   Optional[String]                    $smtpd_tls_session_cache_timeout                        = undef,
   Optional[Variant[Boolean, String]]  $smtpd_tls_wrappermode                                  = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -139,7 +139,7 @@ class postfix::params {
 
       case $facts['os']['release']['major'] {
         '6': {
-          $services         = merge($_services, {
+          $services                 = merge($_services, {
             'pickup/fifo' => {
               'chroot'  => 'n',
               'command' => 'pickup',
@@ -159,11 +159,20 @@ class postfix::params {
               'command' => 'smtp -o smtp_fallback_relay=',
             },
           })
-          $readme_directory = '/usr/share/doc/postfix-2.6.6/README_FILES'
-          $sample_directory = '/usr/share/doc/postfix-2.6.6/samples'
+          $compatibility_level      = undef
+          $meta_directory           = undef
+          $shlib_directory          = undef
+          $readme_directory         = '/usr/share/doc/postfix-2.6.6/README_FILES'
+          $sample_directory         = '/usr/share/doc/postfix-2.6.6/samples'
+          $smtpd_tls_cert_file      = undef
+          $smtpd_tls_key_file       = undef
+          $smtpd_tls_security_level = undef
+          $smtp_tls_capath          = undef
+          $smtp_tls_cafile          = undef
+          $smtp_tls_security_level  = undef
         }
-        default: {
-          $services         = merge($_services, {
+        '7': {
+          $services            = merge($_services, {
             'pickup/unix' => {
               'chroot'  => 'n',
               'command' => 'pickup',
@@ -179,8 +188,56 @@ class postfix::params {
               'wakeup'  => '300',
             },
           })
-          $readme_directory = '/usr/share/doc/postfix-2.10.1/README_FILES'
-          $sample_directory = '/usr/share/doc/postfix-2.10.1/samples'
+          $compatibility_level      = undef
+          $meta_directory           = undef
+          $shlib_directory          = undef
+          $readme_directory         = '/usr/share/doc/postfix-2.10.1/README_FILES'
+          $sample_directory         = '/usr/share/doc/postfix-2.10.1/samples'
+          $smtpd_tls_cert_file      = undef
+          $smtpd_tls_key_file       = undef
+          $smtpd_tls_security_level = undef
+          $smtp_tls_capath          = undef
+          $smtp_tls_cafile          = undef
+          $smtp_tls_security_level  = undef
+        }
+        default: {
+          $services                 = merge($_services, {
+            'pickup/unix' => {
+              'chroot'  => 'n',
+              'command' => 'pickup',
+              'limit'   => '1',
+              'private' => 'n',
+              'wakeup'  => '60',
+            },
+            'qmgr/unix'   => {
+              'chroot'  => 'n',
+              'command' => 'qmgr',
+              'limit'   => '1',
+              'private' => 'n',
+              'wakeup'  => '300',
+            },
+            'postlog/unix-dgram' => {
+              'chroot'  => 'n',
+              'command' => 'postlogd',
+              'limit'   => '1',
+              'private' => 'n',
+            },
+            'relay/unix'  => {
+              'chroot'  => 'n',
+              'command' => 'smtp -o syslog_name=postfix/$service_name',
+            },
+          })
+          $compatibility_level      = '2'
+          $meta_directory           = '/etc/postfix'
+          $shlib_directory          = '/usr/lib64/postfix'
+          $readme_directory         = '/usr/share/doc/postfix/README_FILES'
+          $sample_directory         = '/usr/share/doc/postfix/samples'
+          $smtpd_tls_cert_file      = '/etc/pki/tls/certs/postfix.pem'
+          $smtpd_tls_key_file       = '/etc/pki/tls/private/postfix.key'
+          $smtpd_tls_security_level = 'may'
+          $smtp_tls_capath          = '/etc/pki/tls/certs'
+          $smtp_tls_cafile          = '/etc/pki/tls/certs/ca-bundle.crt'
+          $smtp_tls_security_level  = 'may'
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "herculesteam/augeasproviders_core",
       "version_requirement": ">=2.1.0 <3.0.0"
+    },
+    {
+      "name": "camptocamp/augeas",
+      "version_requirement": ">=1.0.0 <2.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -26,14 +30,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/provision.yaml
+++ b/provision.yaml
@@ -4,3 +4,4 @@ vagrant:
   images:
     - 'generic/centos6'
     - 'generic/centos7'
+    - 'generic/centos8'

--- a/spec/classes/postfix_spec.rb
+++ b/spec/classes/postfix_spec.rb
@@ -20,6 +20,7 @@ describe 'postfix' do
       end
 
       it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_augeas__lens('postfix_master') }
       it { is_expected.to contain_class('postfix') }
       it { is_expected.to contain_class('postfix::config') }
       it { is_expected.to contain_class('postfix::install') }
@@ -78,15 +79,27 @@ describe 'postfix' do
       it { is_expected.to contain_resources('postfix_master') }
       it { is_expected.to contain_service('postfix') }
 
-      case facts[:osfamily]
+      case facts[:os]['family']
       when 'RedHat'
-        case facts[:operatingsystemmajrelease]
-        when '6'
+        if facts[:os]['release']['major'].eql?('6')
           it { is_expected.to contain_postfix_master('pickup/fifo') }
           it { is_expected.to contain_postfix_master('qmgr/fifo') }
         else
           it { is_expected.to contain_postfix_master('pickup/unix') }
           it { is_expected.to contain_postfix_master('qmgr/unix') }
+        end
+
+        if facts[:os]['release']['major'].eql?('8')
+          it { is_expected.to contain_postfix_main('compatibility_level') }
+          it { is_expected.to contain_postfix_main('meta_directory') }
+          it { is_expected.to contain_postfix_main('shlib_directory') }
+          it { is_expected.to contain_postfix_main('smtp_tls_CAfile') }
+          it { is_expected.to contain_postfix_main('smtp_tls_CApath') }
+          it { is_expected.to contain_postfix_main('smtp_tls_security_level') }
+          it { is_expected.to contain_postfix_main('smtpd_tls_cert_file') }
+          it { is_expected.to contain_postfix_main('smtpd_tls_key_file') }
+          it { is_expected.to contain_postfix_main('smtpd_tls_security_level') }
+          it { is_expected.to contain_postfix_master('postlog/unix-dgram') }
         end
       end
     end

--- a/spec/defines/postfix_lookup_database_spec.rb
+++ b/spec/defines/postfix_lookup_database_spec.rb
@@ -36,7 +36,6 @@ describe 'postfix::lookup::database' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to have_exec_resource_count(0) }
         it { is_expected.to contain_file('/etc/postfix/test').that_notifies('Class[postfix::service]') }
         it { is_expected.to contain_postfix__lookup__database('/etc/postfix/test') }
       end


### PR DESCRIPTION
The Augeas lenses bundled with Puppet break on one of the services that
is configured on EL8 so a fixed lens is now installed necessitating
pulling in camptocamp/augeas as a dependency.

Three new parameters have been added as they are set by default, there
are possibly more.

Fixes #16