### PR TITLE
Allow `unix-dgram` in `postfix::master` define

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -23,14 +23,14 @@
 #
 # @since 1.0.0
 define postfix::master (
-  String                                                $command,
-  Pattern[/(?x) ^ [^\/]+ \/ (?:inet|unix|fifo|pass) $/] $service      = $title,
-  Enum['present', 'absent']                             $ensure       = 'present',
-  Optional[Enum['-', 'n', 'y']]                         $private      = undef,
-  Optional[Enum['-', 'n', 'y']]                         $unprivileged = undef,
-  Optional[Enum['-', 'n', 'y']]                         $chroot       = undef,
-  Optional[Pattern[/(?x) ^ (?: - | \d+ [?]? ) $/]]      $wakeup       = undef,
-  Optional[Pattern[/(?x) ^ (?: - | \d+ ) $/]]           $limit        = undef,
+  String                                                           $command,
+  Pattern[/(?x) ^ [^\/]+ \/ (?:inet|unix(?:-dgram)?|fifo|pass) $/] $service      = $title,
+  Enum['present', 'absent']                                        $ensure       = 'present',
+  Optional[Enum['-', 'n', 'y']]                                    $private      = undef,
+  Optional[Enum['-', 'n', 'y']]                                    $unprivileged = undef,
+  Optional[Enum['-', 'n', 'y']]                                    $chroot       = undef,
+  Optional[Pattern[/(?x) ^ (?: - | \d+ [?]? ) $/]]                 $wakeup       = undef,
+  Optional[Pattern[/(?x) ^ (?: - | \d+ ) $/]]                      $limit        = undef,
 ) {
 
   include postfix


### PR DESCRIPTION
Fixes #25