### PR TITLE
Add option for reloading postfix on changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ postfix::lookup::ldap { '/etc/postfix/virtualrecipients.cf':
 }
 ```
 
+## Service management
+
+By default this module restarts the postfix service on config changes.
+
+To prevent clients being disconnected during mail delivery,
+this behaviour can be changed using the parameter `service_restart_command` of class `postfix::init`.
+
+Note, some changes need a restart to get effect:
+[http://www.postfix.org/postconf.5.html](http://www.postfix.org/postconf.5.html)
+
+Example in Hiera for reloading postfix on changes:
+```
+postfix::service_restart_command: '/usr/bin/systemctl reload postfix.service'
+```
+
 ## Reference
 
 The reference documentation is generated with

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -136,6 +136,7 @@ The following parameters are available in the `postfix` class:
 * [`lookup_packages`](#lookup_packages)
 * [`package_name`](#package_name)
 * [`service_name`](#service_name)
+* [`service_restart_command`](#service_restart_command)
 * [`twobounce_notice_recipient`](#twobounce_notice_recipient)
 * [`access_map_defer_code`](#access_map_defer_code)
 * [`access_map_reject_code`](#access_map_reject_code)
@@ -873,6 +874,12 @@ Data type: `String`
 
 
 ##### <a name="service_name"></a>`service_name`
+
+Data type: `String`
+
+
+
+##### <a name="service_restart_command"></a>`service_restart_command`
 
 Data type: `String`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,7 @@ postfix::conf_dir: '/etc/postfix'
 postfix::lookup_packages: {}
 postfix::package_name: 'postfix'
 postfix::service_name: 'postfix'
+postfix::service_restart_command: ~
 postfix::services: {}
 postfix::twobounce_notice_recipient: ~
 postfix::access_map_defer_code: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@
 # @param lookup_packages
 # @param package_name
 # @param service_name
+# @param service_restart_command
 # @param twobounce_notice_recipient `2bounce_notice_recipient` is a violation
 #   of Puppet variable naming conventions.
 # @param access_map_defer_code
@@ -781,6 +782,7 @@ class postfix (
   Hash[Postfix::Type::Lookup, String] $lookup_packages,
   String                              $package_name,
   String                              $service_name,
+  Optional[String]                    $service_restart_command,
   # main.cf parameters below
   Optional[String]                    $twobounce_notice_recipient,
   Optional[String]                    $access_map_defer_code,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,5 +6,6 @@ class postfix::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
+    restart    => $postfix::service_restart_command,
   }
 }


### PR DESCRIPTION
As a system administrator I would like to apply configuration changes to postfix by reloading it.

When using the default service restart behaviour with puppet, the postfix service is restarted.
Rolling out config changes by puppet, could terminate active connections of clients and cause application tasks to fail if those have a poor connection handling.

The module's default service handling is not changed as some users might depend on restarting the service on changes.
Also in some situations a restart of postfix is required to make changes effective: http://www.postfix.org/postconf.5.html