### PR TITLE
Fix support for /etc/aliases

### DIFF
--- a/manifests/lookup/database.pp
+++ b/manifests/lookup/database.pp
@@ -24,11 +24,12 @@
 #
 # @since 1.0.0
 define postfix::lookup::database (
-  Enum['present', 'absent']       $ensure  = 'present',
-  Stdlib::Absolutepath            $path    = $title,
-  Postfix::Type::Lookup::Database $type    = $postfix::default_database_type,
-  Optional[String]                $content = undef,
-  Optional[String]                $source  = undef,
+  Enum['present', 'absent']       $ensure      = 'present',
+  Stdlib::Absolutepath            $path        = $title,
+  Postfix::Type::Lookup::Database $type        = $postfix::default_database_type,
+  Enum['lookup', 'aliases']       $input_type  = 'lookup',
+  Optional[String]                $content     = undef,
+  Optional[String]                $source      = undef,
 ) {
 
   include postfix
@@ -96,7 +97,16 @@ define postfix::lookup::database (
         $memo + ["[ -f ${x} ]", "[ $(stat -c '%Y' ${x}) -gt $(stat -c '%Y' ${path}) ]"]
       }, ' && ')
 
-      exec { "postmap ${type}:${path}":
+      case $input_type {
+          'lookup': {
+            $postcmd = 'postmap'
+          }
+          'aliases': {
+            $postcmd = 'postalias'
+          }
+      }
+
+      exec { "${postcmd} ${type}:${path}":
         path    => $::path,
         unless  => $unless,
         require => File[$path],

--- a/spec/acceptance/postfix_spec.rb
+++ b/spec/acceptance/postfix_spec.rb
@@ -8,7 +8,8 @@ describe 'postfix' do
       }
 
       postfix::lookup::database { '/etc/aliases':
-        type => 'hash',
+        type       => 'hash',
+        input_type => 'aliases',
       }
 
       Mailalias <||> -> Postfix::Lookup::Database['/etc/aliases']


### PR DESCRIPTION
Prior to this commit we used postmap to create the database for all files, including /etc/aliases. However, the traditional sendmail format of /etc/aliases differs from the expected input for postmap. The sendmail format uses a colon and whitespace to separate keys and values, whereas postfix's lookup format, just uses whitespace. This necessitates using postalias when creating databases for sendmail alias files.

I'm not sure how the postfix acceptance test passed prior to this change, but at least in my testing this change is required for it to pass.